### PR TITLE
feat: add github acction for deploy docker to Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,28 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:14.17.4 as build
 WORKDIR /app
 COPY . .
 RUN npm install
-RUN npm build
-
+RUN npm run build
 
 # Serve static site
 FROM nginx:alpine


### PR DESCRIPTION
Add github action for automate publish docker image to Docker Hub and fixed Dockerfile incorrect at build step.

***Before merge mush setting secret of setting that following:**
- DOCKER_USERNAME: username of Docker Hub
- DOCKER_PASSWORD: password of Docker Hub
- DOCKER_TAGS: tag name of docker image

Resolve: #4 
